### PR TITLE
Minor update to AsciiDoc examples

### DIFF
--- a/markup-comparison.adoc
+++ b/markup-comparison.adoc
@@ -176,6 +176,11 @@ a|
 . second item
 .. first subitem of an item
 . third item
+
+[loweralpha]
+. first item
+. second item
+. third item
 ----
 
 a|
@@ -297,7 +302,7 @@ a|
   
 ----
 The block can also be
-enclosed by -.
+enclosed by 4 - or . chars.
 ----
 
 a|


### PR DESCRIPTION
- Show example of setting numeration type in ordered list
- Mention that literal can be fenced by 4 hyphen or 4 dot chars
